### PR TITLE
Comply with expected format: value and str format

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,13 +2,12 @@ import sys
 import random
 import json
 
+# An inference example as a random number.
 random_number = random.randint(1, 100)
 
  # Create Dictionary
 value = {
-    "number": random_number,
-    "arguments": sys.argv,
+    "value": str(random_number)
 }
- 
 
 print(json.dumps(value))


### PR DESCRIPTION
Current example needs fixes to comply with format expected by heads:
* field is called `value` 
* value is provided as a string.