### PR TITLE
fix topicId typo

### DIFF
--- a/allora-inference-function/index.ts
+++ b/allora-inference-function/index.ts
@@ -18,7 +18,7 @@ if (envVars) {
 				if (rs == true) {
 					const SEP = "\r\n";
 					let buf = new Array<u8>(1024);
-					let req = `{"arguments":["${environmentValue.toString()}"], "topicId":"${envTopicId}"}`;
+					let req = `{"arguments":["${environmentValue.toString()}"], "topicid":"${envTopicId}"}`;
 					let req_len = req.length;
 					let head = `${req_len}${SEP}`;
 					command.stdinWriteString(head);


### PR DESCRIPTION
Topic Id is coming as an empty string. 
However the code is executing, which means the TopicId is read, but passed incorrectly to the request so the topicId remains empty.

